### PR TITLE
Change name of output file

### DIFF
--- a/utils/convert.ts
+++ b/utils/convert.ts
@@ -29,7 +29,7 @@ export default async function convertFile(
   videoSettings: VideoInputSettings
 ): Promise<any> {
   const { file, fileName, fileType } = actionFile;
-  const output = removeFileExtension(fileName) + "." + videoSettings.videoType;
+  const output = removeFileExtension(fileName) + "-converted" + "."  + videoSettings.videoType;
   ffmpeg.writeFile(fileName, await fetchFile(file));
   const command = videoSettings.twitterCompressionCommand
     ? twitterCompressionCommand(fileName, output)


### PR DESCRIPTION
Append "-converted" to output file name to prevent ffmpeg from exiting due to same name as input.

Fixes #2 and #3.